### PR TITLE
`expires => undef` means that expires is not specified.

### DIFF
--- a/lib/Cookie/Baker.pm
+++ b/lib/Cookie/Baker.pm
@@ -33,7 +33,7 @@ sub bake_cookie {
     my $cookie = "$name=" . URI::Escape::uri_escape($args{value}) . '; ';
     $cookie .= 'domain=' . $args{domain} . '; '  if $args{domain};
     $cookie .= 'path='. $args{path} . '; '       if $args{path};
-    $cookie .= 'expires=' . _date($args{expires}) . '; ' if exists $args{expires};
+    $cookie .= 'expires=' . _date($args{expires}) . '; ' if exists $args{expires} && defined $args{expires};
     $cookie .= 'max-age=' . $args{"max-age"} . '; ' if $args{"max-age"};
     $cookie .= 'secure; '                     if $args{secure};
     $cookie .= 'HttpOnly; '                   if $args{httponly};

--- a/t/01_bake.t
+++ b/t/01_bake.t
@@ -10,6 +10,7 @@ my @tests = (
     [ 'foo', 'val', 'foo=val'],
     [ 'foo', { value => 'val' }, 'foo=val'],
     [ 'foo', { value => 'foo bar baz' }, 'foo=foo%20bar%20baz'],
+    [ 'foo', { value => 'val',expires => undef }, 'foo=val'],
     [ 'foo', { value => 'val',path => '/' }, 'foo=val; path=/'],
     [ 'foo', { value => 'val',path => '/', secure => 1, httponly => 0 }, 'foo=val; path=/; secure'],
     [ 'foo', { value => 'val',path => '/', secure => 0, httponly => 1 }, 'foo=val; path=/; HttpOnly'],


### PR DESCRIPTION
c88febd breaks a test of [Ark](https://github.com/ark-framework/ark).
ref. ark-framework/ark#10

I think Cookie::Baker should accept `expires => undef` because of compatibility.
How do you think?
