### PR TITLE
Support SameSite=None

### DIFF
--- a/lib/Cookie/Baker.pm
+++ b/lib/Cookie/Baker.pm
@@ -39,7 +39,7 @@ sub bake_cookie {
     $cookie .= 'path='. $args{path} . '; '       if $args{path};
     $cookie .= 'expires=' . _date($args{expires}) . '; ' if exists $args{expires} && defined $args{expires};
     $cookie .= 'max-age=' . $args{"max-age"} . '; ' if exists $args{"max-age"};
-    if (exists $args{samesite} && $args{samesite} =~ m/^(?:lax|strict)/i) {
+    if (exists $args{samesite} && $args{samesite} =~ m/^(?:lax|strict|none)/i) {
         $cookie .= 'SameSite=' . ucfirst(lc($args{samesite})) . '; '
     }
     $cookie .= 'secure; '                     if $args{secure};
@@ -200,9 +200,9 @@ If true, sets secure flag. false by default.
 
 =item samesite
 
-If defined as 'lax' or 'strict' (case-insensitive), sets the SameSite restriction for the cookie as described in the
+If defined as 'lax' or 'strict' or 'none' (case-insensitive), sets the SameSite restriction for the cookie as described in the
 L<draft proposal|https://tools.ietf.org/html/draft-west-first-party-cookies-07>, which is already implemented in
-Chrome (v51), Opera (v38) and Firefox (v60).
+Chrome (v51), Safari (v12), Edge (v16),  Opera (v38) and Firefox (v60).
 
 =back
 

--- a/t/01_bake.t
+++ b/t/01_bake.t
@@ -31,6 +31,7 @@ my @tests = (
     [ 'foo', { value => 'val','max-age' => '0' }, 'foo=val; max-age=0'],
     [ 'foo', { value => 'val', samesite => 'lax' }, 'foo=val; SameSite=Lax'],
     [ 'foo', { value => 'val', samesite => 'strict' }, 'foo=val; SameSite=Strict'],
+    [ 'foo', { value => 'val', samesite => 'none' }, 'foo=val; SameSite=None'],
     [ 'foo', { value => 'val', samesite => 'invalid value' }, 'foo=val'],
 );
 


### PR DESCRIPTION
In this PR, "None" can be specified as the value of SameSite attribute.
As background, to support the following announcements of Chrome.
[Cookies with SameSite by default - Chrome Platform Status](https://www.chromestatus.com/feature/5088147346030592)