### PR TITLE
Support CHIPS (Cookies Having Independent Partitioned State)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ There is no XS implementation of bake\_cookie yet.
     Generates a cookie string for an HTTP response header.
     The first argument is the cookie's name and the second argument is a plain string or hash reference that
     can contain keys such as `value`, `domain`, `expires`, `path`, `httponly`, `secure`,
-    `max-age`, `samesite`.
+    `max-age`, `samesite`, `partitioned`.
 
     - value
 
@@ -81,6 +81,11 @@ There is no XS implementation of bake\_cookie yet.
         If defined as 'lax' or 'strict' or 'none' (case-insensitive), sets the SameSite restriction for the cookie as described in the
         [draft proposal](https://tools.ietf.org/html/draft-west-first-party-cookies-07), which is already implemented in
         Chrome (v51), Safari (v12), Edge (v16),  Opera (v38) and Firefox (v60).
+
+    - partitioned
+
+        If true, sets Partitioned flag, and also enforces secure, SameSite=None. false by default.
+        [Cookies Having Independent Partitioned State specification](https://www.ietf.org/archive/id/draft-cutler-httpbis-partitioned-cookies-00.html)
 
 - crush\_cookie
 

--- a/lib/Cookie/Baker.pm
+++ b/lib/Cookie/Baker.pm
@@ -33,6 +33,11 @@ sub bake_cookie {
 
     return '' unless defined $val;
     my %args = ref $val ? %{$val} : (value => $val);
+    if ($args{partitioned}) {
+        # enforce SameSite=None; and secure; on CHIPS (Cookies Having Independent Partitioned State)
+        $args{samesite} = 'none';
+        $args{secure} = 1;
+    }
     $name = URI::Escape::uri_escape($name) if $name =~ m![^a-zA-Z\-\._~]!;
     my $cookie = "$name=" . URI::Escape::uri_escape($args{value}) . '; ';
     $cookie .= 'domain=' . $args{domain} . '; '  if $args{domain};
@@ -44,6 +49,8 @@ sub bake_cookie {
     }
     $cookie .= 'secure; '                     if $args{secure};
     $cookie .= 'HttpOnly; '                   if $args{httponly};
+    $cookie .= 'Partitioned; '                if $args{partitioned};
+
     substr($cookie,-2,2,'');
     $cookie;
 }

--- a/t/01_bake.t
+++ b/t/01_bake.t
@@ -12,8 +12,10 @@ my @tests = (
     [ 'foo', { value => 'foo bar baz' }, 'foo=foo%20bar%20baz'],
     [ 'foo', { value => 'val',expires => undef }, 'foo=val'],
     [ 'foo', { value => 'val',path => '/' }, 'foo=val; path=/'],
-    [ 'foo', { value => 'val',path => '/', secure => 1, httponly => 0 }, 'foo=val; path=/; secure'],
-    [ 'foo', { value => 'val',path => '/', secure => 0, httponly => 1 }, 'foo=val; path=/; HttpOnly'],
+    [ 'foo', { value => 'val',path => '/', secure => 0, httponly => 0, partitioned => 0 }, 'foo=val; path=/'],
+    [ 'foo', { value => 'val',path => '/', secure => 1, httponly => 0, partitioned => 0 }, 'foo=val; path=/; secure'],
+    [ 'foo', { value => 'val',path => '/', secure => 0, httponly => 1, partitioned => 0 }, 'foo=val; path=/; HttpOnly'],
+    [ 'foo', { value => 'val',path => '/', secure => 0, httponly => 0, partitioned => 1 }, 'foo=val; path=/; SameSite=None; secure; Partitioned'],
     [ 'foo', { value => 'val',expires => 'now' }, 'foo=val; expires=Mon, 07-Oct-2013 13:56:57 GMT'],
     [ 'foo', { value => 'val',expires => $now + 24*60*60 }, 'foo=val; expires=Tue, 08-Oct-2013 13:56:57 GMT'],
     [ 'foo', { value => 'val',expires => '1s' }, 'foo=val; expires=Mon, 07-Oct-2013 13:56:58 GMT'],
@@ -33,6 +35,7 @@ my @tests = (
     [ 'foo', { value => 'val', samesite => 'strict' }, 'foo=val; SameSite=Strict'],
     [ 'foo', { value => 'val', samesite => 'none' }, 'foo=val; SameSite=None'],
     [ 'foo', { value => 'val', samesite => 'invalid value' }, 'foo=val'],
+    [ 'foo', { value => 'val', samesite => 'strict', partitioned => 1 }, 'foo=val; SameSite=None; secure; Partitioned'],
 );
 
 for my $test (@tests) {


### PR DESCRIPTION
In this PR, we add support for the `Partitioned` attribute promoted by Chrome.

reference:
[privacycg/CHIPS: A proposal for a cookie attribute to partition cross-site cookies by top-level site](https://github.com/privacycg/CHIPS)
[IETF updates RFC6265bis draft](https://www.ietf.org/archive/id/draft-cutler-httpbis-partitioned-cookies-00.html)