### PR TITLE
Set secure when SameSite=None

### DIFF
--- a/lib/Cookie/Baker.pm
+++ b/lib/Cookie/Baker.pm
@@ -40,7 +40,9 @@ sub bake_cookie {
     $cookie .= 'expires=' . _date($args{expires}) . '; ' if exists $args{expires} && defined $args{expires};
     $cookie .= 'max-age=' . $args{"max-age"} . '; ' if exists $args{"max-age"};
     if (exists $args{samesite} && $args{samesite} =~ m/^(?:lax|strict|none)/i) {
-        $cookie .= 'SameSite=' . ucfirst(lc($args{samesite})) . '; '
+        $cookie .= 'SameSite=' . ucfirst(lc($args{samesite})) . '; ';
+        # secure flag must be set when SameSite=None
+        $args{secure} = 1 if $cookie =~ m/SameSite=None; /;
     }
     $cookie .= 'secure; '                     if $args{secure};
     $cookie .= 'HttpOnly; '                   if $args{httponly};

--- a/t/01_bake.t
+++ b/t/01_bake.t
@@ -31,7 +31,8 @@ my @tests = (
     [ 'foo', { value => 'val','max-age' => '0' }, 'foo=val; max-age=0'],
     [ 'foo', { value => 'val', samesite => 'lax' }, 'foo=val; SameSite=Lax'],
     [ 'foo', { value => 'val', samesite => 'strict' }, 'foo=val; SameSite=Strict'],
-    [ 'foo', { value => 'val', samesite => 'none' }, 'foo=val; SameSite=None'],
+    [ 'foo', { value => 'val', samesite => 'none' }, 'foo=val; SameSite=None; secure'],
+    [ 'foo', { value => 'val', samesite => 'none', secure => 0 }, 'foo=val; SameSite=None; secure'],
     [ 'foo', { value => 'val', samesite => 'invalid value' }, 'foo=val'],
 );
 


### PR DESCRIPTION
In this PR, we enforces secure flag on when SameSite attribute is `None`.

reference:
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#none
> The Secure attribute must also be set when setting this value, like so SameSite=None; Secure. 